### PR TITLE
Feature/10 extract user

### DIFF
--- a/src/main/java/samryong/auth/controller/AuthController.java
+++ b/src/main/java/samryong/auth/controller/AuthController.java
@@ -12,6 +12,8 @@ import samryong.auth.dto.AuthResponseDTO;
 import samryong.auth.dto.AuthResponseDTO.LoginResponse;
 import samryong.auth.service.AuthService;
 import samryong.global.response.ApiResponse;
+import samryong.member.domain.Member;
+import samryong.security.resolver.annotation.AuthMember;
 import samryong.security.resolver.annotation.GetToken;
 
 @RestController
@@ -35,7 +37,7 @@ public class AuthController {
     }
 
     @GetMapping("/test")
-    public ApiResponse<String> testAuth() {
-        return ApiResponse.onSuccess("인증 성공", "인증 성공");
+    public ApiResponse<String> testAuth(@AuthMember Member member) {
+        return ApiResponse.onSuccess("인증 성공", "인증 성공 + " + member.getId());
     }
 }

--- a/src/main/java/samryong/auth/converter/KakaoAuthConverter.java
+++ b/src/main/java/samryong/auth/converter/KakaoAuthConverter.java
@@ -12,7 +12,7 @@ public class KakaoAuthConverter {
     public static Member toMember(HashMap<String, Object> userInfo) {
         return Member.builder()
                 .email((String) userInfo.get("email"))
-                .nicName((String) userInfo.get("nickname"))
+                .nickName((String) userInfo.get("nickname"))
                 .build();
     }
 
@@ -20,7 +20,7 @@ public class KakaoAuthConverter {
             String accessToken, String refreshToken, Member member) {
         return LoginResponse.builder()
                 .id(member.getId())
-                .name(member.getNicName())
+                .name(member.getNickName())
                 .token(AuthToken.builder().accessToken(accessToken).refreshToken(refreshToken).build())
                 .build();
     }

--- a/src/main/java/samryong/global/config/WebConfig.java
+++ b/src/main/java/samryong/global/config/WebConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import samryong.security.resolver.AuthMemberArgumentResolver;
 import samryong.security.resolver.GetTokenArgumentResolver;
 
 @RequiredArgsConstructor
@@ -12,9 +13,11 @@ import samryong.security.resolver.GetTokenArgumentResolver;
 public class WebConfig implements WebMvcConfigurer {
 
     private final GetTokenArgumentResolver getTokenArgumentResolver;
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(getTokenArgumentResolver);
+        resolvers.add(authMemberArgumentResolver);
     }
 }

--- a/src/main/java/samryong/member/domain/Member.java
+++ b/src/main/java/samryong/member/domain/Member.java
@@ -24,7 +24,7 @@ public class Member {
     private Long id;
 
     @Column(columnDefinition = "varchar(30)")
-    private String nicName;
+    private String nickName;
 
     @Column(columnDefinition = "varchar(50)")
     private String email;

--- a/src/main/java/samryong/member/service/MemberService.java
+++ b/src/main/java/samryong/member/service/MemberService.java
@@ -1,3 +1,8 @@
 package samryong.member.service;
 
-public interface MemberService {}
+import samryong.member.domain.Member;
+
+public interface MemberService {
+
+    Member getMember(Long memberId);
+}

--- a/src/main/java/samryong/member/service/MemberServiceImpl.java
+++ b/src/main/java/samryong/member/service/MemberServiceImpl.java
@@ -2,7 +2,17 @@ package samryong.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import samryong.member.domain.Member;
+import samryong.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
-public class MemberServiceImpl implements MemberService {}
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Member getMember(Long memberId) {
+        return memberRepository.findById(memberId).orElse(null);
+    }
+}

--- a/src/main/java/samryong/security/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/samryong/security/resolver/AuthMemberArgumentResolver.java
@@ -41,7 +41,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
 
         if (authentication != null) {
             if (authentication.getName().equals("anonymousUser")) {
-                throw new GlobalException(GlobalErrorCode._BAD_REQUEST);
+                throw new GlobalException(GlobalErrorCode._UNAUTHORIZED);
             } else {
                 principal = authentication.getPrincipal();
             }

--- a/src/main/java/samryong/security/resolver/AuthMemberArgumentResolver.java
+++ b/src/main/java/samryong/security/resolver/AuthMemberArgumentResolver.java
@@ -1,0 +1,59 @@
+package samryong.security.resolver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import samryong.global.code.GlobalErrorCode;
+import samryong.global.exception.GlobalException;
+import samryong.member.domain.Member;
+import samryong.member.service.MemberService;
+import samryong.security.resolver.annotation.AuthMember;
+
+@Component
+@RequiredArgsConstructor
+public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthMember.class)
+                && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+
+        Object principal = null;
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null) {
+            if (authentication.getName().equals("anonymousUser")) {
+                throw new GlobalException(GlobalErrorCode._BAD_REQUEST);
+            } else {
+                principal = authentication.getPrincipal();
+            }
+        }
+
+        if (principal == null || principal.getClass() == String.class) {
+            throw new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                (UsernamePasswordAuthenticationToken) authentication;
+
+        return memberService.getMember(Long.valueOf(usernamePasswordAuthenticationToken.getName()));
+    }
+}

--- a/src/main/java/samryong/security/resolver/annotation/AuthMember.java
+++ b/src/main/java/samryong/security/resolver/annotation/AuthMember.java
@@ -1,0 +1,12 @@
+package samryong.security.resolver.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Parameter(hidden = true)
+public @interface AuthMember {}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #10

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- @AuthMember 어노테이션을 통해 인증 정보만을 가지고 사용자 식별 정보를 추출할 수 있는 기능 추가
- @AuthMember 어노테이션 선언
- @AuthMember 기능 구현 resolver 정의 및 등록
- Member 엔터티의 별명 필드 nicName -> nickName 스펠링 오류 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?