### PR TITLE
✨ [Feat] 농협 계좌이체 기능을 위한 농협 오픈 API와 통신 기능 구현

### DIFF
--- a/src/main/java/samryong/bank/nonghyup/dto/request/BankTransferRequestDTO.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/request/BankTransferRequestDTO.java
@@ -1,0 +1,29 @@
+package samryong.bank.nonghyup.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BankTransferRequestDTO {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DepositRequestDTO { // 입금 이체 API 요청 DTO
+
+        private String accountNum; // 계좌번호
+        private String transferAmount; // 거래금액
+        private String depositOtlt; // 입금계좌인자내용
+        private String withdrawOtlt; // 출금계좌인자내용
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WithdrawRequestDTO { // 출금 이체 API 요청 DTO
+
+        private String finAcno; // 핀-어카운트번호
+        private String transferAmount; // 거래금액
+        private String withdrawOtlt; // 출금계좌인자내용
+    }
+}

--- a/src/main/java/samryong/bank/nonghyup/dto/response/CheckOpenFinAccountDirectResponseDTO.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/response/CheckOpenFinAccountDirectResponseDTO.java
@@ -1,0 +1,16 @@
+package samryong.bank.nonghyup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheckOpenFinAccountDirectResponseDTO { // 핀테크 발급 확인 API 응답 DTO
+
+    @JsonProperty("FinAcno")
+    private String FinAcno; // 핀-어카운트번호
+
+    @JsonProperty("Header")
+    private ResponseHeader Header; // 응답헤더
+}

--- a/src/main/java/samryong/bank/nonghyup/dto/response/DrawingTransferResponseDTO.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/response/DrawingTransferResponseDTO.java
@@ -1,0 +1,16 @@
+package samryong.bank.nonghyup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DrawingTransferResponseDTO { // 출금 이체 API 응답 DTO
+
+    @JsonProperty("Header")
+    private ResponseHeader Header; // 응답헤더
+
+    @JsonProperty("FinAcno")
+    private String FinAcno; // 핀-어카운트번호
+}

--- a/src/main/java/samryong/bank/nonghyup/dto/response/OpenFinAccountDirectResponseDTO.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/response/OpenFinAccountDirectResponseDTO.java
@@ -1,0 +1,16 @@
+package samryong.bank.nonghyup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OpenFinAccountDirectResponseDTO { // 핀테크 핀-어카운트 직접발급 API 응답 DTO
+
+    @JsonProperty("Rgno")
+    private String Rgno; // 등록번호
+
+    @JsonProperty("Header")
+    private ResponseHeader Header; // 응답헤더
+}

--- a/src/main/java/samryong/bank/nonghyup/dto/response/ReceivedTransferAccountNumberResponseDTO.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/response/ReceivedTransferAccountNumberResponseDTO.java
@@ -1,0 +1,13 @@
+package samryong.bank.nonghyup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReceivedTransferAccountNumberResponseDTO { // 입금 이체 API 응답 DTO
+
+    @JsonProperty("Header")
+    private ResponseHeader Header; // 응답헤더
+}

--- a/src/main/java/samryong/bank/nonghyup/dto/response/ResponseHeader.java
+++ b/src/main/java/samryong/bank/nonghyup/dto/response/ResponseHeader.java
@@ -1,0 +1,16 @@
+package samryong.bank.nonghyup.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponseHeader { // 응답 헤더
+
+    @JsonProperty("Rpcd")
+    private String Rpcd; // 응답코드, 정상처리코드 : 00000
+
+    @JsonProperty("Rsms")
+    private String Rsms; // 응답메시지
+}

--- a/src/main/java/samryong/bank/nonghyup/exception/NonghyupException.java
+++ b/src/main/java/samryong/bank/nonghyup/exception/NonghyupException.java
@@ -1,0 +1,15 @@
+package samryong.bank.nonghyup.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class NonghyupException extends RuntimeException {
+
+    // 농협 API 응답으로부터 오는 에러 코드와 메시지를 담는 클래스
+    private HttpStatus httpStatus;
+    private String code;
+    private String message;
+}

--- a/src/main/java/samryong/bank/nonghyup/provider/NonghyupTransactionProvider.java
+++ b/src/main/java/samryong/bank/nonghyup/provider/NonghyupTransactionProvider.java
@@ -1,0 +1,195 @@
+package samryong.bank.nonghyup.provider;
+
+import static org.springframework.http.HttpMethod.POST;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import samryong.bank.nonghyup.dto.request.BankTransferRequestDTO.DepositRequestDTO;
+import samryong.bank.nonghyup.dto.request.BankTransferRequestDTO.WithdrawRequestDTO;
+import samryong.bank.nonghyup.dto.response.CheckOpenFinAccountDirectResponseDTO;
+import samryong.bank.nonghyup.dto.response.DrawingTransferResponseDTO;
+import samryong.bank.nonghyup.dto.response.OpenFinAccountDirectResponseDTO;
+import samryong.bank.nonghyup.dto.response.ReceivedTransferAccountNumberResponseDTO;
+import samryong.bank.nonghyup.exception.NonghyupException;
+
+@Component
+@RequiredArgsConstructor
+public class NonghyupTransactionProvider {
+
+    @Value("${nonghyup.api.access-token}")
+    private String accessToken; // 접근 토큰
+
+    @Value("${nonghyup.api.iscd}")
+    private String iscd; // 이용기관 코드
+
+    @Value("${nonghyup.api.fintech-apsno}")
+    private String fintechApsno; // 핀테크 앱 일련번호, 테스트 시 001로 고정
+
+    @Value("${nonghyup.api.brdt-brno}")
+    private String brdtBrno; // 생년월일/사업자번호
+
+    // 핀테크 발급 요청, 계좌번호를 받아 핀테크 발급 확인을 위한 고유번호를 반환
+    public String openFinAccountDirect(String accountNum) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("Header", createCommonHeader("OpenFinAccountDirect", "DrawingTransferA"));
+        body.put("DrtrRgyn", "Y"); // 출금이체 등록여부
+        body.put("BrdtBrno", brdtBrno); // 생년월일/사업자번호
+        body.put("Bncd", "011"); // 농협계좌 은행코드
+        body.put("Acno", accountNum); // 계좌번호
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, httpHeaders);
+
+        ResponseEntity<OpenFinAccountDirectResponseDTO> response =
+                restTemplate.exchange(
+                        "https://developers.nonghyup.com/OpenFinAccountDirect.nh",
+                        POST,
+                        request,
+                        OpenFinAccountDirectResponseDTO.class);
+        OpenFinAccountDirectResponseDTO responseBody = response.getBody();
+
+        if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
+            return responseBody.getRgno();
+        } else {
+            throw new NonghyupException(
+                    HttpStatus.BAD_REQUEST,
+                    responseBody.getHeader().getRpcd(),
+                    responseBody.getHeader().getRsms());
+        }
+    }
+
+    // 핀테크 발급 확인
+    public String checkOpenFinAccountDirect(String rgno) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("Header", createCommonHeader("CheckOpenFinAccountDirect", "DrawingTransferA"));
+        body.put("Rgno", rgno); // 등록번호
+        body.put("BrdtBrno", brdtBrno); // 생년월일/사업자번호
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, httpHeaders);
+
+        ResponseEntity<CheckOpenFinAccountDirectResponseDTO> response =
+                restTemplate.exchange(
+                        "https://developers.nonghyup.com/CheckOpenFinAccountDirect.nh",
+                        POST,
+                        request,
+                        CheckOpenFinAccountDirectResponseDTO.class);
+        CheckOpenFinAccountDirectResponseDTO responseBody = response.getBody();
+
+        if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
+            return responseBody.getFinAcno();
+        } else {
+            throw new NonghyupException(
+                    HttpStatus.BAD_REQUEST,
+                    responseBody.getHeader().getRpcd(),
+                    responseBody.getHeader().getRsms());
+        }
+    }
+
+    // 입금 이체, 핀테크 기업 약정 계좌에서 개인 농협 계좌로 입금 이체
+    public void receivedTransferAccountNumber(DepositRequestDTO requestDTO) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("Header", createCommonHeader("ReceivedTransferAccountNumber", "ReceivedTransferA"));
+        body.put("Acno", requestDTO.getAccountNum()); // 계좌번호
+        body.put("Tram", requestDTO.getTransferAmount()); // 거래금액
+        body.put("DractOtlt", requestDTO.getWithdrawOtlt()); // 출금계좌인자내용
+        body.put("MractOtlt", requestDTO.getDepositOtlt()); // 입금계좌인자내용
+        body.put("Bncd", "011"); // 농협계좌 은행코드
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, httpHeaders);
+
+        ResponseEntity<ReceivedTransferAccountNumberResponseDTO> response =
+                restTemplate.exchange(
+                        "https://developers.nonghyup.com/ReceivedTransferAccountNumber.nh",
+                        POST,
+                        request,
+                        ReceivedTransferAccountNumberResponseDTO.class);
+
+        ReceivedTransferAccountNumberResponseDTO responseBody = response.getBody();
+
+        if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
+            return;
+        } else {
+            throw new NonghyupException(
+                    HttpStatus.BAD_REQUEST,
+                    responseBody.getHeader().getRpcd(),
+                    responseBody.getHeader().getRsms());
+        }
+    }
+
+    // 출금 이체, 개인 농협 계좌에서 핀테크 기업 약정 계좌로 출금 이체
+    public void drawingTransfer(WithdrawRequestDTO requestDTO) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("Header", createCommonHeader("DrawingTransfer", "DrawingTransferA"));
+        body.put("FinAcno", requestDTO.getFinAcno()); // 핀-어카운트번호
+        body.put("Tram", requestDTO.getTransferAmount()); // 거래금액
+        body.put("DractOtlt", requestDTO.getWithdrawOtlt()); // 출금계좌인자내용
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, httpHeaders);
+
+        ResponseEntity<DrawingTransferResponseDTO> response =
+                restTemplate.exchange(
+                        "https://developers.nonghyup.com/DrawingTransfer.nh",
+                        POST,
+                        request,
+                        DrawingTransferResponseDTO.class);
+
+        DrawingTransferResponseDTO responseBody = response.getBody();
+
+        if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
+            return;
+        } else {
+            throw new NonghyupException(
+                    HttpStatus.BAD_REQUEST,
+                    responseBody.getHeader().getRpcd(),
+                    responseBody.getHeader().getRsms());
+        }
+    }
+
+    // 공통 헤더부
+    private Map<String, Object> createCommonHeader(String apiName, String apiSvcCd) {
+
+        Map<String, Object> header = new HashMap<>();
+        header.put("ApiNm", apiName); // API명
+        header.put(
+                "Tsymd", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))); // 전송일자
+        header.put("Trtm", LocalDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss"))); // 전송시간
+        header.put("Iscd", iscd); // 이용기관코드
+        header.put("FintechApsno", fintechApsno); // 핀테크 앱 일련번호
+        header.put("ApiSvcCd", apiSvcCd); // API서비스코드
+        header.put(
+                "IsTuno",
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"))); // 기관거래고유번호
+        header.put("AccessToken", accessToken); // 접근 토큰
+
+        return header;
+    }
+}

--- a/src/main/java/samryong/global/exception/ExceptionAdvice.java
+++ b/src/main/java/samryong/global/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import samryong.bank.nonghyup.exception.NonghyupException;
 import samryong.global.code.GlobalErrorCode;
 import samryong.global.response.ErrorResponse;
 
@@ -18,8 +19,19 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(e.getGlobalErrorCode());
     }
 
+    @ExceptionHandler(NonghyupException.class)
+    public ResponseEntity<ErrorResponse> handleNonghyupException(NonghyupException e) {
+        log.error("{}: {}", e.getCode(), e.getMessage());
+        return handleExceptionInternal(e);
+    }
+
     private ResponseEntity<ErrorResponse> handleExceptionInternal(GlobalErrorCode globalErrorCode) {
         return ResponseEntity.status(globalErrorCode.getHttpStatus().value())
                 .body(new ErrorResponse(globalErrorCode));
+    }
+
+    private ResponseEntity<ErrorResponse> handleExceptionInternal(NonghyupException e) {
+        return ResponseEntity.status(e.getHttpStatus().value())
+                .body(new ErrorResponse(e.getCode(), e.getMessage()));
     }
 }

--- a/src/main/java/samryong/global/response/ErrorResponse.java
+++ b/src/main/java/samryong/global/response/ErrorResponse.java
@@ -15,4 +15,10 @@ public class ErrorResponse {
         this.code = globalErrorCode.getCode();
         this.message = globalErrorCode.getMessage();
     }
+
+    public ErrorResponse(String code, String message) {
+        this.isSuccess = false;
+        this.code = code;
+        this.message = message;
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,3 +30,10 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: ${JWT_ACCESS_TOKEN_TIME}
   refresh-token-validity: ${JWT_REFRESH_TOKEN_TIME}
+
+nonghyup:
+  api:
+    access-token: ${NONGHYUP_ACCESS_TOKEN} # 농협 API Access Token
+    iscd : ${NONGHYUP_ISCD} # 농협 API ISCD, 기관 코드
+    fintech-apsno: "001" # 농협 API FintechApsno, 핀테크 앱 일련번호, 테스트 시 001로 고정
+    brdt-brno: ${NONGHYUP_BRDT_BRNO} # 농협 API BrdtBrno, 테스트 예금주 생년월일

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -31,4 +31,11 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: ${JWT_ACCESS_TOKEN_TIME}
   refresh-token-validity: ${JWT_REFRESH_TOKEN_TIME}
+  
+nonghyup:
+  api:
+    access-token: ${NONGHYUP_ACCESS_TOKEN} # 농협 API Access Token
+    iscd : ${NONGHYUP_ISCD} # 농협 API ISCD, 기관 코드
+    fintech-apsno: "001" # 농협 API FintechApsno, 핀테크 앱 일련번호, 테스트 시 001로 고정
+    brdt-brno: ${NONGHYUP_BRDT_BRNO} # 농협 API BrdtBrno, 테스트 예금주 생년월일
 '''


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #14 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 핀테크 어카운트 발급 요청 api 호출 기능 추가, 고객 계좌의 등록번호를 반환해요.(출금이체 기능을 위해서는 고객 계좌의 핀테크 어카운트가 필요하기 때문에 추가)
- 핀테크 발급 확인 api 호출 기능 추가, 등록 번호를 통해 최종적인 핀테크를 발급받아요.
- 입금이체 api 호출 기능 추가, 모계좌에서 고객 계좌로 돈이 입금됩니다.
- 출금이체 api 호출 기능 추가, 고객 계좌에서 모계좌로 돈이 출금됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?