### PR TITLE
✨ [Feat] ChatMessage, ChatRoom, Rent 엔터티, 컨트롤러, 서비스, 리포지터리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'

--- a/src/main/java/samryong/SamryongApplication.java
+++ b/src/main/java/samryong/SamryongApplication.java
@@ -2,10 +2,12 @@ package samryong;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableMongoRepositories
 public class SamryongApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/samryong/chat/controller/ChatController.java
+++ b/src/main/java/samryong/chat/controller/ChatController.java
@@ -1,0 +1,12 @@
+package samryong.chat.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+@Tag(name = "Chat", description = "채팅 관련 API")
+public class ChatController {}

--- a/src/main/java/samryong/chat/domain/ChatMessage.java
+++ b/src/main/java/samryong/chat/domain/ChatMessage.java
@@ -1,0 +1,51 @@
+package samryong.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document("chat_message")
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_message_id")
+    private String id; // MongoBDB ID는 스트링으로 설정
+
+    private Long chatRoomId; // 채팅방 ID
+
+    private Long senderId; // 보낸 사람 ID
+
+    private String message; // 메시지 텍스트
+
+    private String imageUri; // 사진
+
+    private LocalDateTime createdAt; // 메시지 생성 시간
+
+    @Enumerated(EnumType.STRING)
+    private ChatType type;
+
+    public enum ChatType {
+        TEXT, // 일반 텍스트 메시지
+        IMAGE, // 이미지 메시지
+        RENT_REQ, // 물품 대여 요청
+        RENT_RES, // 물품 대여 응답
+        RET_REQ, // 물품 반납 요청
+        RET_RES, // 물품 반납 응답
+        DEPOSIT_RES, // 보증금 요청
+    }
+}

--- a/src/main/java/samryong/chat/domain/ChatRoom.java
+++ b/src/main/java/samryong/chat/domain/ChatRoom.java
@@ -1,0 +1,42 @@
+package samryong.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import samryong.global.BaseEntity;
+import samryong.member.domain.Member;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_id")
+    private Long id; // 채팅방 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item; // 물품 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id")
+    private Member owner; // 물품 등록자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "renter_id")
+    private Member renter; // 물품 대여자
+}

--- a/src/main/java/samryong/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/samryong/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package samryong.chat.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import samryong.chat.domain.ChatMessage;
+
+@Repository
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {}

--- a/src/main/java/samryong/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/samryong/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package samryong.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import samryong.chat.domain.ChatRoom;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {}

--- a/src/main/java/samryong/chat/service/ChatService.java
+++ b/src/main/java/samryong/chat/service/ChatService.java
@@ -1,0 +1,3 @@
+package samryong.chat.service;
+
+public interface ChatService {}

--- a/src/main/java/samryong/chat/service/ChatServiceImpl.java
+++ b/src/main/java/samryong/chat/service/ChatServiceImpl.java
@@ -1,0 +1,8 @@
+package samryong.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {}

--- a/src/main/java/samryong/global/BaseEntity.java
+++ b/src/main/java/samryong/global/BaseEntity.java
@@ -1,0 +1,19 @@
+package samryong.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @CreatedDate private LocalDateTime createdAt;
+
+    @LastModifiedDate private LocalDateTime updatedDate;
+}

--- a/src/main/java/samryong/rent/domain/Rent.java
+++ b/src/main/java/samryong/rent/domain/Rent.java
@@ -1,0 +1,58 @@
+package samryong.rent.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import samryong.member.domain.Member;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Rent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rent_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "renter_id")
+    private Member renter; // 대여자
+
+    private LocalDateTime startDate; // 대여 시작일
+
+    private LocalDateTime endDate; // 대여 종료일
+
+    private Long overDueFee; // 연체료
+
+    @Enumerated(EnumType.STRING)
+    private RentStatus status; // 대여 상태
+
+    public enum RentStatus {
+        REQUEST, // 대여 요청
+        ACCEPT, // 대여 승인
+        RENT_PROCESS, // 대여 진행
+        RETURN_REQUEST, // 반납 요청
+        RETURN_ACCEPT, // 반납 승인
+        OVERDUE, // 연체
+    }
+}

--- a/src/main/java/samryong/rent/domain/Rent.java
+++ b/src/main/java/samryong/rent/domain/Rent.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import samryong.global.BaseEntity;
 import samryong.member.domain.Member;
 
 @Entity
@@ -23,7 +24,7 @@ import samryong.member.domain.Member;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Rent {
+public class Rent extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/samryong/rent/repository/RentRepository.java
+++ b/src/main/java/samryong/rent/repository/RentRepository.java
@@ -1,0 +1,8 @@
+package samryong.rent.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import samryong.rent.domain.Rent;
+
+@Repository
+public interface RentRepository extends JpaRepository<Rent, Long> {}

--- a/src/main/java/samryong/rent/service/RentService.java
+++ b/src/main/java/samryong/rent/service/RentService.java
@@ -1,0 +1,3 @@
+package samryong.rent.service;
+
+public interface RentService {}

--- a/src/main/java/samryong/rent/service/RentServiceImpl.java
+++ b/src/main/java/samryong/rent/service/RentServiceImpl.java
@@ -1,0 +1,8 @@
+package samryong.rent.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RentServiceImpl implements RentService {}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,8 @@ spring:
       hibernate:
         format_sql: true
   data:
+    mongodb:
+      uri: mongodb://localhost:27017/samryong
     redis:
       host: localhost
       port: 6379

--- a/src/main/resources/application-server.yml
+++ b/src/main/resources/application-server.yml
@@ -19,6 +19,8 @@ spring:
       hibernate:
         format_sql: true
   data:
+    mongodb:
+      uri: ${MONGODB_URL}
     redis:
       host: ${REDIS_URL}
       port: 6379


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #12 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- ChatMessage, ChatRoom, Rent에 대한 도메인, 리포지터리, 서비스 클래스를 구성했어요.
- ChatMessage는 추후 확장성을 위해 MongoDB를 사용했어요
- MongoDB 설정 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?