### PR TITLE
✨ [Feat] ElasticSearch를 이용한 물품 검색 API 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.17.9
+
+# Nori 플러그인을 설치
+RUN elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -65,12 +65,15 @@ dependencies {
 
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-  
+
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 	// stomp
 	implementation 'org.webjars:stomp-websocket:2.3.4'
+
+	// elastic search
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+services:
+  es:
+    build:
+      context: .
+      dockerfile: Dockerfile  # 루트 디렉토리의 Dockerfile 사용
+    container_name: es
+    environment:
+      - node.name=single-node
+      - cluster.name=backtony
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+      - 9300:9300
+    networks:
+      - es-bridge
+
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:7.17.9
+    environment:
+      SERVER_NAME: kibana
+      # Elasticsearch 기본 호스트는 http://elasticsearch:9200 이다.
+      # 현재 docker-compose 파일에 Elasticsearch 서비스 명은 es로 설정되어있다.
+      ELASTICSEARCH_HOSTS: http://es:9200
+    ports:
+      - 5601:5601
+    # Elasticsearch Start Dependency
+    depends_on:
+      - es
+    networks:
+      - es-bridge
+
+networks:
+  es-bridge:
+    driver: bridge

--- a/src/main/java/samryong/domain/item/contorller/ItemController.java
+++ b/src/main/java/samryong/domain/item/contorller/ItemController.java
@@ -9,6 +9,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import samryong.domain.item.dto.CategoryDTO.CategoryRequestDTO;
+import samryong.domain.item.dto.ItemDTO.ItemListRequestDTO;
+import samryong.domain.item.dto.ItemDTO.ItemPreviewListResponseDTO;
 import samryong.domain.item.dto.ItemDTO.ItemRequestDTO;
 import samryong.domain.item.service.category.CategoryService;
 import samryong.domain.item.service.item.ItemService;
@@ -42,5 +44,13 @@ public class ItemController {
     public ApiResponse<Long> createCategory(
             @AuthMember Member member, @RequestBody @Valid CategoryRequestDTO categoryDTO) {
         return ApiResponse.onSuccess("카테고리 등록 성공", categoryService.createCategory(categoryDTO));
+    }
+
+    @PostMapping("/search")
+    @Operation(summary = "물품 검색", description = "물품명, 물품 설명, 카테고리, 위치를 통해 물품을 검색합니다.")
+    public ApiResponse<ItemPreviewListResponseDTO> searchItem(
+            @RequestBody @Valid ItemListRequestDTO requestDTO,
+            @RequestParam(value = "page", defaultValue = "0", required = false) int page) {
+        return ApiResponse.onSuccess("물품 검색 성공", itemService.searchItem(requestDTO, page));
     }
 }

--- a/src/main/java/samryong/domain/item/converter/CategoryConverter.java
+++ b/src/main/java/samryong/domain/item/converter/CategoryConverter.java
@@ -1,6 +1,7 @@
 package samryong.domain.item.converter;
 
 import org.springframework.stereotype.Component;
+import samryong.domain.item.document.CategoryDocument;
 import samryong.domain.item.dto.CategoryDTO.CategoryRequestDTO;
 import samryong.domain.item.entity.Category;
 
@@ -9,5 +10,9 @@ public class CategoryConverter {
 
     public static Category toCategory(CategoryRequestDTO requestDTO) {
         return Category.builder().name(requestDTO.getName()).build();
+    }
+
+    public static CategoryDocument toCategoryDocument(Category category) {
+        return CategoryDocument.builder().id(category.getId()).name(category.getName()).build();
     }
 }

--- a/src/main/java/samryong/domain/item/converter/ItemConverter.java
+++ b/src/main/java/samryong/domain/item/converter/ItemConverter.java
@@ -1,8 +1,18 @@
 package samryong.domain.item.converter;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
+import samryong.domain.image.Image;
+import samryong.domain.item.document.ItemDocument;
+import samryong.domain.item.dto.ItemDTO.ItemPreviewListResponseDTO;
+import samryong.domain.item.dto.ItemDTO.ItemPreviewResponseDTO;
 import samryong.domain.item.dto.ItemDTO.ItemRequestDTO;
+import samryong.domain.item.entity.Category;
 import samryong.domain.item.entity.Item;
+import samryong.domain.location.converter.LocationConverter;
 import samryong.domain.location.entity.Location;
 import samryong.domain.member.entity.Member;
 
@@ -18,6 +28,57 @@ public class ItemConverter {
                 .deposit(requestDTO.getDeposit())
                 .location(location)
                 .member(member)
+                .build();
+    }
+
+    public static ItemDocument toItemDocument(Item item, List<Category> categoryList) {
+        return ItemDocument.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .createdDate(item.getCreatedAt().toString())
+                .status(String.valueOf(item.getStatus()))
+                .description(item.getDescription())
+                .period(item.getPeriod())
+                .fee(item.getFee())
+                .deposit(item.getDeposit())
+                .location(LocationConverter.toLocationDocument(item.getLocation()))
+                .imageUrlList(
+                        item.getImageList() != null
+                                ? item.getImageList().stream().map(Image::getImageUri).collect(Collectors.toList())
+                                : Collections.emptyList())
+                .itemCategoryList(
+                        categoryList.stream()
+                                .map(CategoryConverter::toCategoryDocument)
+                                .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static ItemPreviewResponseDTO toItemPreviewResponseDTO(ItemDocument itemDocument) {
+        return ItemPreviewResponseDTO.builder()
+                .id(itemDocument.getId())
+                .name(itemDocument.getName())
+                .status(itemDocument.getStatus())
+                .fee(itemDocument.getFee())
+                .createdDate(itemDocument.getCreatedDate())
+                .deposit(itemDocument.getDeposit())
+                .imageUrl(
+                        itemDocument.getImageUrlList() != null && !itemDocument.getImageUrlList().isEmpty()
+                                ? itemDocument.getImageUrlList().get(0)
+                                : null)
+                .location(LocationConverter.toLocationResponseDTO(itemDocument.getLocation()))
+                .build();
+    }
+
+    public static ItemPreviewListResponseDTO toItemPreviewResponseListDTO(
+            Page<ItemDocument> itemDocumentList) {
+        return ItemPreviewListResponseDTO.builder()
+                .totalPage(itemDocumentList.getTotalPages())
+                .currentElement(itemDocumentList.getNumberOfElements())
+                .totalElement(itemDocumentList.getTotalElements())
+                .itemPreviewResponseDTOList(
+                        itemDocumentList.getContent().stream()
+                                .map(ItemConverter::toItemPreviewResponseDTO)
+                                .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/samryong/domain/item/document/CategoryDocument.java
+++ b/src/main/java/samryong/domain/item/document/CategoryDocument.java
@@ -1,0 +1,27 @@
+package samryong.domain.item.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "category", writeTypeHint = WriteTypeHint.FALSE)
+@Setting(settingPath = "elastic/post-setting.json")
+public class CategoryDocument {
+
+    @Id private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String name; // 카테고리명
+}

--- a/src/main/java/samryong/domain/item/document/ItemDocument.java
+++ b/src/main/java/samryong/domain/item/document/ItemDocument.java
@@ -1,0 +1,58 @@
+package samryong.domain.item.document;
+
+import static org.springframework.data.elasticsearch.annotations.FieldType.Keyword;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+import samryong.domain.location.document.LocationDocument;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "item", writeTypeHint = WriteTypeHint.FALSE)
+@Setting(settingPath = "elastic/post-setting.json")
+public class ItemDocument {
+
+    @Id private Long id;
+
+    @Field(type = Keyword, analyzer = "korean")
+    private String name; // 상품명
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String description; // 상품 설명
+
+    @Field(type = Keyword, analyzer = "korean")
+    private String createdDate; // 상품 등록 날짜
+
+    @Field(type = Keyword)
+    private String status; // 상품 상태
+
+    @Field(type = FieldType.Long)
+    private Long period; // 대여 가능 기간
+
+    @Field(type = FieldType.Long)
+    private Long fee; // 대여료
+
+    @Field(type = FieldType.Long)
+    private Long deposit; // 보증금
+
+    @Field(type = Keyword)
+    private List<String> imageUrlList; // 이미지 URL 목록
+
+    @Field(type = FieldType.Nested, includeInParent = true)
+    private List<CategoryDocument> itemCategoryList; // 상품 카테고리 목록
+
+    @Field(type = FieldType.Nested, includeInParent = true)
+    private LocationDocument location; // 위치 정보
+}

--- a/src/main/java/samryong/domain/item/dto/ItemDTO.java
+++ b/src/main/java/samryong/domain/item/dto/ItemDTO.java
@@ -5,10 +5,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import samryong.domain.item.dto.CategoryDTO.CategoryRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationResponseDTO;
 
 public class ItemDTO {
 
@@ -37,5 +41,53 @@ public class ItemDTO {
         private Long deposit;
 
         private ArrayList<CategoryRequestDTO> categoryList;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemListRequestDTO {
+
+        private String keyword;
+
+        private CategoryRequestDTO category;
+
+        private LocationRequestDTO location;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemPreviewResponseDTO {
+
+        // 아이템 전체 조회 시에 대한 미리 보기 응답
+        private Long id;
+
+        private String name;
+
+        private String status;
+
+        private String createdDate;
+
+        private Long fee;
+
+        private Long deposit;
+
+        private String imageUrl; // 이미지 목록 중 첫번째 값
+
+        private LocationResponseDTO location;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemPreviewListResponseDTO {
+
+        private int currentElement; // 현재 페이지 아이템 개수
+        private int totalPage; // 전체 페이지
+        private long totalElement; // 전체 아이템 개수
+        private List<ItemPreviewResponseDTO> itemPreviewResponseDTOList;
     }
 }

--- a/src/main/java/samryong/domain/item/repository/elastic/CategoryElasticRepository.java
+++ b/src/main/java/samryong/domain/item/repository/elastic/CategoryElasticRepository.java
@@ -1,0 +1,9 @@
+package samryong.domain.item.repository.elastic;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+import samryong.domain.item.document.CategoryDocument;
+
+@Repository
+public interface CategoryElasticRepository
+        extends ElasticsearchRepository<CategoryDocument, Long> {}

--- a/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepository.java
+++ b/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepository.java
@@ -1,0 +1,9 @@
+package samryong.domain.item.repository.elastic;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+import samryong.domain.item.document.ItemDocument;
+
+@Repository
+public interface ItemElasticRepository
+        extends ElasticsearchRepository<ItemDocument, Long>, ItemElasticRepositoryCustom {}

--- a/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepositoryCustom.java
+++ b/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepositoryCustom.java
@@ -1,0 +1,16 @@
+package samryong.domain.item.repository.elastic;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import samryong.domain.item.document.ItemDocument;
+
+public interface ItemElasticRepositoryCustom {
+
+    Page<ItemDocument> searchItem(
+            String keyword,
+            String categoryName,
+            String city,
+            String district,
+            String neighborhood,
+            Pageable pageable);
+}

--- a/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepositoryImpl.java
+++ b/src/main/java/samryong/domain/item/repository/elastic/ItemElasticRepositoryImpl.java
@@ -1,0 +1,67 @@
+package samryong.domain.item.repository.elastic;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Repository;
+import samryong.domain.item.document.ItemDocument;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemElasticRepositoryImpl implements ItemElasticRepositoryCustom {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public Page<ItemDocument> searchItem(
+            String keyword,
+            String categoryName,
+            String city,
+            String district,
+            String neighborhood,
+            Pageable pageable) {
+
+        Criteria criteria = buildCriteria(keyword, categoryName, city, district, neighborhood);
+        Sort sort = Sort.by(Sort.Order.desc("createdDate")); // 내림차순 정렬 (최신순)
+
+        CriteriaQuery query = new CriteriaQuery(criteria).addSort(sort).setPageable(pageable);
+
+        SearchHits<ItemDocument> searchHits = elasticsearchOperations.search(query, ItemDocument.class);
+        List<ItemDocument> itemDocumentList =
+                searchHits.stream().map(SearchHit::getContent).collect(Collectors.toList());
+
+        return new PageImpl<>(itemDocumentList, pageable, searchHits.getTotalHits());
+    }
+
+    private Criteria buildCriteria(
+            String keyword, String categoryName, String city, String district, String neighborhood) {
+
+        Criteria criteria = new Criteria();
+
+        if (isNotEmpty(keyword)) {
+            for (String key : keyword.split("\\s+")) {
+                criteria = criteria.or("name").contains(key).or("description").contains(key);
+            }
+        }
+
+        if (isNotEmpty(categoryName)) criteria = criteria.and("itemCategoryList.name").is(categoryName);
+        if (isNotEmpty(city)) criteria = criteria.and("location.city").is(city);
+        if (isNotEmpty(district)) criteria = criteria.and("location.district").is(district);
+        if (isNotEmpty(neighborhood)) criteria = criteria.and("location.neighborhood").is(neighborhood);
+
+        return criteria;
+    }
+
+    private boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
+    }
+}

--- a/src/main/java/samryong/domain/item/service/category/CategoryService.java
+++ b/src/main/java/samryong/domain/item/service/category/CategoryService.java
@@ -10,5 +10,7 @@ public interface CategoryService {
 
     Category getCategoryByName(String name);
 
+    Category findCategoryByName(String name);
+
     Long createCategory(CategoryRequestDTO categoryDTO);
 }

--- a/src/main/java/samryong/domain/item/service/category/CategoryServiceImpl.java
+++ b/src/main/java/samryong/domain/item/service/category/CategoryServiceImpl.java
@@ -7,6 +7,7 @@ import samryong.domain.item.converter.CategoryConverter;
 import samryong.domain.item.dto.CategoryDTO.CategoryRequestDTO;
 import samryong.domain.item.entity.Category;
 import samryong.domain.item.repository.CategoryRepository;
+import samryong.domain.item.repository.elastic.CategoryElasticRepository;
 import samryong.global.code.GlobalErrorCode;
 import samryong.global.exception.GlobalException;
 
@@ -15,6 +16,7 @@ import samryong.global.exception.GlobalException;
 public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final CategoryElasticRepository categoryElasticRepository;
 
     @Override
     public List<Category> getCategoryList(List<CategoryRequestDTO> categoryList) {
@@ -32,9 +34,15 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
+    public Category findCategoryByName(String name) {
+        return categoryRepository.findByName(name).orElse(null);
+    }
+
+    @Override
     public Long createCategory(CategoryRequestDTO categoryDTO) {
         Category category = CategoryConverter.toCategory(categoryDTO);
         categoryRepository.save(category);
+        categoryElasticRepository.save(CategoryConverter.toCategoryDocument(category));
         return category.getId();
     }
 }

--- a/src/main/java/samryong/domain/item/service/item/ItemService.java
+++ b/src/main/java/samryong/domain/item/service/item/ItemService.java
@@ -2,6 +2,8 @@ package samryong.domain.item.service.item;
 
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
+import samryong.domain.item.dto.ItemDTO;
+import samryong.domain.item.dto.ItemDTO.ItemListRequestDTO;
 import samryong.domain.item.dto.ItemDTO.ItemRequestDTO;
 import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
 import samryong.domain.member.entity.Member;
@@ -13,4 +15,6 @@ public interface ItemService {
             ItemRequestDTO itemDTO,
             LocationRequestDTO locationDTO,
             List<MultipartFile> imageList);
+
+    ItemDTO.ItemPreviewListResponseDTO searchItem(ItemListRequestDTO requestDTO, int page);
 }

--- a/src/main/java/samryong/domain/item/service/item/ItemServiceImpl.java
+++ b/src/main/java/samryong/domain/item/service/item/ItemServiceImpl.java
@@ -4,10 +4,16 @@ import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import samryong.domain.image.ImageConverter;
 import samryong.domain.item.converter.ItemConverter;
+import samryong.domain.item.document.ItemDocument;
+import samryong.domain.item.dto.ItemDTO.ItemListRequestDTO;
+import samryong.domain.item.dto.ItemDTO.ItemPreviewListResponseDTO;
 import samryong.domain.item.dto.ItemDTO.ItemRequestDTO;
 import samryong.domain.item.entity.Category;
 import samryong.domain.item.entity.Item;
@@ -15,13 +21,13 @@ import samryong.domain.item.entity.ItemCategory;
 import samryong.domain.item.repository.CategoryRepository;
 import samryong.domain.item.repository.ItemCategoryRepository;
 import samryong.domain.item.repository.ItemRepository;
+import samryong.domain.item.repository.elastic.ItemElasticRepository;
 import samryong.domain.item.service.category.CategoryService;
 import samryong.domain.item.service.itemCategory.ItemCategoryService;
 import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
 import samryong.domain.location.entity.Location;
 import samryong.domain.location.service.LocationService;
 import samryong.domain.member.entity.Member;
-import samryong.domain.member.repository.MemberRepository;
 import samryong.domain.uuid.Uuid;
 import samryong.domain.uuid.UuidRepository;
 import samryong.global.aws.AmazonS3Manager;
@@ -38,7 +44,7 @@ public class ItemServiceImpl implements ItemService {
     private final ItemCategoryService itemCategoryService;
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager amazonS3Manager;
-    private final MemberRepository memberRepository;
+    private final ItemElasticRepository itemElasticRepository;
 
     @Override
     @Transactional
@@ -62,7 +68,29 @@ public class ItemServiceImpl implements ItemService {
 
         categoryRepository.saveAll(categoryList);
         itemCategoryRepository.saveAll(itemCategoryList);
+        itemElasticRepository.save(ItemConverter.toItemDocument(item, categoryList));
         return item.getId();
+    }
+
+    @Override
+    public ItemPreviewListResponseDTO searchItem(ItemListRequestDTO requestDTO, int page) {
+
+        String keyword = requestDTO.getKeyword();
+        Category category = categoryService.findCategoryByName(requestDTO.getCategory().getName());
+        String categoryName = category != null ? category.getName() : null;
+        Location location = locationService.getLocation(requestDTO.getLocation());
+        Pageable pageable = PageRequest.of(page, 4);
+
+        Page<ItemDocument> itemDocumentPage =
+                itemElasticRepository.searchItem(
+                        keyword,
+                        categoryName,
+                        location.getCity(),
+                        location.getDistrict(),
+                        location.getNeighborhood(),
+                        pageable);
+
+        return ItemConverter.toItemPreviewResponseListDTO(itemDocumentPage);
     }
 
     private Item prepareNewItem(ItemRequestDTO requestDto, Location location, Member member) {

--- a/src/main/java/samryong/domain/location/converter/LocationConverter.java
+++ b/src/main/java/samryong/domain/location/converter/LocationConverter.java
@@ -1,7 +1,9 @@
 package samryong.domain.location.converter;
 
 import org.springframework.stereotype.Component;
+import samryong.domain.location.document.LocationDocument;
 import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationResponseDTO;
 import samryong.domain.location.entity.Location;
 
 @Component
@@ -12,6 +14,23 @@ public class LocationConverter {
                 .city(requestDTO.getCity())
                 .district(requestDTO.getDistrict())
                 .neighborhood(requestDTO.getNeighborhood())
+                .build();
+    }
+
+    public static LocationDocument toLocationDocument(Location location) {
+        return LocationDocument.builder()
+                .id(location.getId())
+                .city(location.getCity())
+                .district(location.getDistrict())
+                .neighborhood(location.getNeighborhood())
+                .build();
+    }
+
+    public static LocationResponseDTO toLocationResponseDTO(LocationDocument locationdocument) {
+        return LocationResponseDTO.builder()
+                .city(locationdocument.getCity())
+                .district(locationdocument.getDistrict())
+                .neighborhood(locationdocument.getNeighborhood())
                 .build();
     }
 }

--- a/src/main/java/samryong/domain/location/document/LocationDocument.java
+++ b/src/main/java/samryong/domain/location/document/LocationDocument.java
@@ -1,0 +1,33 @@
+package samryong.domain.location.document;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "location", writeTypeHint = WriteTypeHint.FALSE)
+@Setting(settingPath = "elastic/post-setting.json")
+public class LocationDocument {
+
+    @Id private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String city;
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String district;
+
+    @Field(type = FieldType.Text, analyzer = "korean")
+    private String neighborhood;
+}

--- a/src/main/java/samryong/domain/location/dto/LocationDTO.java
+++ b/src/main/java/samryong/domain/location/dto/LocationDTO.java
@@ -2,6 +2,7 @@ package samryong.domain.location.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,17 @@ public class LocationDTO {
         private String district;
 
         @NotBlank(message = "주소는 필수 입력입니다.")
+        private String neighborhood;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LocationResponseDTO {
+
+        private String city;
+        private String district;
         private String neighborhood;
     }
 }

--- a/src/main/java/samryong/domain/location/repository/LocationElasticRepository.java
+++ b/src/main/java/samryong/domain/location/repository/LocationElasticRepository.java
@@ -1,0 +1,9 @@
+package samryong.domain.location.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+import samryong.domain.location.document.LocationDocument;
+
+@Repository
+public interface LocationElasticRepository
+        extends ElasticsearchRepository<LocationDocument, Long> {}

--- a/src/main/java/samryong/domain/location/service/LocationServiceImpl.java
+++ b/src/main/java/samryong/domain/location/service/LocationServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import samryong.domain.location.converter.LocationConverter;
 import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
 import samryong.domain.location.entity.Location;
+import samryong.domain.location.repository.LocationElasticRepository;
 import samryong.domain.location.repository.LocationRepository;
 import samryong.global.code.GlobalErrorCode;
 import samryong.global.exception.GlobalException;
@@ -14,6 +15,7 @@ import samryong.global.exception.GlobalException;
 public class LocationServiceImpl implements LocationService {
 
     private final LocationRepository locationRepository;
+    private final LocationElasticRepository locationElasticRepository;
 
     @Override
     public Location getLocation(LocationRequestDTO requestDTO) {
@@ -27,6 +29,8 @@ public class LocationServiceImpl implements LocationService {
     public Long createLocation(LocationRequestDTO locationDTO) {
         Location location = LocationConverter.toLocation(locationDTO);
         locationRepository.save(location);
+        locationElasticRepository.save(LocationConverter.toLocationDocument(location));
+
         return location.getId();
     }
 }

--- a/src/main/java/samryong/global/config/ElasticSearchConfig.java
+++ b/src/main/java/samryong/global/config/ElasticSearchConfig.java
@@ -1,0 +1,18 @@
+package samryong.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.elasticsearch.host}")
+    private String host;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder().connectedTo(host).build();
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,6 +23,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  elasticsearch:
+    host: localhost:9200
 
 kakao:
   client: ${KAKAO_CLIENT_ID} # REST-API 키

--- a/src/main/resources/elastic/post-setting.json
+++ b/src/main/resources/elastic/post-setting.json
@@ -1,0 +1,9 @@
+{
+  "analysis": {
+    "analyzer": {
+      "korean": {
+        "type": "nori"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #26

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Dockerfile 및 Docker-Compose.yml을 이용한 ElasticSearch 설치 및 연동
- Criteria를 이용하여 검색 쿼리 생성
- 카테고리, 위치, 키워드 기반한 검색 및 페이징 기능 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?