### PR TITLE
[Feat] 채팅방 목록 조회 api 및 채팅방 업데이트 기능 구현

### DIFF
--- a/src/main/java/samryong/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/samryong/domain/chat/controller/ChatRoomController.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import samryong.domain.chat.aspect.annotation.AuthChatMember;
+import samryong.domain.chat.dto.ChatMessageDTO.ChatMessageRequestDTO;
 import samryong.domain.chat.dto.ChatMessageDTO.ChatMessageResponseListDTO;
+import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomListResponseDTO;
 import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomRequestDTO;
 import samryong.domain.chat.service.ChatMessageService;
 import samryong.domain.chat.service.ChatRoomService;
@@ -41,5 +43,18 @@ public class ChatRoomController {
     public ApiResponse<ChatMessageResponseListDTO> getMessageList(
             @RequestParam(value = "roomId") Long roomId) {
         return ApiResponse.onSuccess("채팅방 메시지 조회 성공", chatMessageService.getMessageList(roomId));
+    }
+
+    @Operation(summary = "사용자 채팅방 목록 전체 조회", description = "사용자의 채팅방 목록을 전체 조회합니다.")
+    @GetMapping("/room/list")
+    public ApiResponse<ChatRoomListResponseDTO> getChatRoomList(@AuthMember Member member) {
+        return ApiResponse.onSuccess("사용자 채팅방 목록 조회 성공", chatRoomService.getChatRoomList(member));
+    }
+
+    @Operation(summary = "채팅 메시지 보내기 테스트 api", description = "채팅 메시지를 보냅니다.")
+    @PostMapping("/message")
+    public ApiResponse<String> message(@RequestBody ChatMessageRequestDTO requestDTO) {
+        chatMessageService.publishMessage(requestDTO);
+        return ApiResponse.onSuccess("메시지 전송 성공", "");
     }
 }

--- a/src/main/java/samryong/domain/chat/converter/ChatRoomConverter.java
+++ b/src/main/java/samryong/domain/chat/converter/ChatRoomConverter.java
@@ -1,7 +1,13 @@
 package samryong.domain.chat.converter;
 
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import org.springframework.stereotype.Component;
+import samryong.domain.chat.dto.ChatRoomDTO;
 import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomHashDTO;
+import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomListResponseDTO;
+import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomResponseDTO;
+import samryong.domain.chat.entity.ChatMessage;
 import samryong.domain.chat.entity.ChatRoom;
 import samryong.domain.item.entity.Item;
 import samryong.domain.member.entity.Member;
@@ -11,6 +17,28 @@ public class ChatRoomConverter {
 
     public static ChatRoom toChatRoom(Member renter, Member owner, Item item) {
         return ChatRoom.builder().renter(renter).owner(owner).item(item).build();
+    }
+
+    public static ChatRoomResponseDTO toChatRoomResponseDTO(
+            ChatRoom chatRoom, ChatMessage lastMessage) {
+        return ChatRoomDTO.ChatRoomResponseDTO.builder()
+                .chatRoomId(chatRoom.getId())
+                .ownerName(chatRoom.getOwner().getNickName())
+                .renterName(chatRoom.getRenter().getNickName())
+                .itemName(chatRoom.getItem().getName())
+                .updatedDate(
+                        chatRoom.getUpdatedDate() != null
+                                ? chatRoom
+                                        .getUpdatedDate()
+                                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                                : "날짜 없음") // 기본값 설정
+                .lastMessage(lastMessage != null ? lastMessage.getMessage() : "메시지 없음") // 기본값 설정
+                .build();
+    }
+
+    public static ChatRoomListResponseDTO toChatRoomListResponseDTO(
+            List<ChatRoomResponseDTO> chatRoomList) {
+        return ChatRoomListResponseDTO.builder().chatRoomList(chatRoomList).build();
     }
 
     public static ChatRoomHashDTO toChatRoomHashDTO(ChatRoom chatRoom) {

--- a/src/main/java/samryong/domain/chat/dto/ChatRoomDTO.java
+++ b/src/main/java/samryong/domain/chat/dto/ChatRoomDTO.java
@@ -2,6 +2,7 @@ package samryong.domain.chat.dto;
 
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,33 @@ public class ChatRoomDTO {
 
         @NotNull(message = "물품 등록자 ID는 필수 입력 값입니다.")
         private Long ownerId; // 물품 등록자 ID
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChatRoomResponseDTO {
+
+        private Long chatRoomId; // 채팅방 ID
+
+        private String itemName; // 물품 이름
+
+        private String ownerName; // 물품 등록자 이름
+
+        private String renterName; // 물품 대여자 이름
+
+        private String updatedDate; // 채팅방 최근 메시지 업데이트 시간
+
+        private String lastMessage; // 채팅방 마지막 메시지
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChatRoomListResponseDTO {
+        List<ChatRoomResponseDTO> chatRoomList;
     }
 
     @Getter

--- a/src/main/java/samryong/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/samryong/domain/chat/repository/ChatMessageRepository.java
@@ -9,4 +9,6 @@ import samryong.domain.chat.entity.ChatMessage;
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
     List<ChatMessage> findTop100ByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
+
+    ChatMessage findTopByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 }

--- a/src/main/java/samryong/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/samryong/domain/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,8 @@
 package samryong.domain.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import samryong.domain.chat.entity.ChatRoom;
@@ -10,4 +12,6 @@ import samryong.domain.member.entity.Member;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByRenterAndOwnerAndItem(Member renter, Member owner, Item item);
+
+    List<ChatRoom> findAllByRenterOrOwner(Member renter, Member owner, Sort sort);
 }

--- a/src/main/java/samryong/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/samryong/domain/chat/service/ChatRoomService.java
@@ -1,7 +1,9 @@
 package samryong.domain.chat.service;
 
 import org.springframework.data.redis.listener.ChannelTopic;
+import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomListResponseDTO;
 import samryong.domain.chat.dto.ChatRoomDTO.ChatRoomRequestDTO;
+import samryong.domain.chat.entity.ChatMessage;
 import samryong.domain.member.entity.Member;
 
 public interface ChatRoomService {
@@ -13,4 +15,10 @@ public interface ChatRoomService {
     ChannelTopic getTopic(Long chatRoomId);
 
     boolean isMemberOfChatRoom(Long roomId, Long memberId);
+
+    ChatRoomListResponseDTO getChatRoomList(Member member);
+
+    void updateChatRoomLastMessage(Long chatRoomId);
+
+    ChatMessage getLastMessage(Long roomId);
 }

--- a/src/main/java/samryong/global/BaseEntity.java
+++ b/src/main/java/samryong/global/BaseEntity.java
@@ -16,4 +16,12 @@ public abstract class BaseEntity {
     @CreatedDate private LocalDateTime createdAt;
 
     @LastModifiedDate private LocalDateTime updatedDate;
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setUpdatedDate(LocalDateTime updatedDate) {
+        this.updatedDate = updatedDate;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #37 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅방 목록 조회 api를 구현했어요
- 채팅방 목록 조회 시 채팅방 마지막 업데이트 시간, 마지막 메시지를 반환하고, 마지막 업데이트 시간에 맞게 최신순으로 정렬해요
- 채팅방 목록 조회 시 반환된는 마지막 업데이트 시간, 메시지를 업데이트하는 함수를 추가했어요
- 채팅 메시지 발생하는 정렬 오류를 수정했어요

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?