### PR TITLE
🐛 : [Bug] 채팅 송/수신 메시지 간 채팅 시간 차이 오류 수정

### DIFF
--- a/src/main/java/samryong/domain/chat/converter/ChatMessageConverter.java
+++ b/src/main/java/samryong/domain/chat/converter/ChatMessageConverter.java
@@ -22,7 +22,7 @@ public class ChatMessageConverter {
                 .senderId(responseDTO.getSenderId())
                 .message(responseDTO.getMessage())
                 .imageUri(responseDTO.getImageUri())
-                .createdAt(responseDTO.getCreatedAt())
+                .createdAt(TimeZoneUtil.toPlus9Hours(responseDTO.getCreatedAt())) // KST -> UTC 변환
                 .type(responseDTO.getType())
                 .build();
     }
@@ -46,7 +46,7 @@ public class ChatMessageConverter {
                 .senderId(requestDTO.getSenderId())
                 .message(requestDTO.getMessage())
                 .imageUri(requestDTO.getImageUri())
-                .createdAt(TimeZoneUtil.toPlus9Hours(LocalDateTime.now())) // KST -> UTC 변환
+                .createdAt(LocalDateTime.now())
                 .type(requestDTO.getType())
                 .build();
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #61 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅 송/수신 메시지 간의 타임 존 차이 오류를 해결하였습니다
-
-

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?