### PR TITLE
:bug; [Bug] 채팅방 조회로 인해 몽고 DB에서 Redis로 채팅 메시지 로드 안되는 오류 수정

### DIFF
--- a/src/main/java/samryong/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/samryong/domain/chat/service/ChatRoomServiceImpl.java
@@ -162,12 +162,21 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         if (latestMessage == null) {
 
-            latestMessage = chatMessageRepository.findTopByChatRoomIdOrderByCreatedAtDesc(roomId);
+            List<ChatMessage> dbMessageList =
+                    chatMessageRepository.findTop100ByChatRoomIdOrderByCreatedAtDesc(roomId);
 
-            if (latestMessage == null) return null;
+            if (dbMessageList == null || dbMessageList.isEmpty()) {
+                return null;
+            }
 
             redisTemplateMessage.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
-            redisTemplateMessage.opsForList().leftPush(key, latestMessage);
+
+            // MongoDB에서 가져온 메시지를 Redis에 저장
+            for (ChatMessage chatMessage : dbMessageList) {
+                redisTemplateMessage.opsForList().leftPush(key, chatMessage);
+            }
+
+            latestMessage = dbMessageList.get(0);
         }
 
         return latestMessage;


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #61 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅방의 마지막 메시지가 조회가 먼저 이루어져서 몽고DB에서 Redis로 데이터가 1개만 로드되는 오류를 수정
- 채팅방 마지막 메시지를 업데이트 할 때도 Redis에 데이터가 없는 경우 전체 메시지를 로드할 수 있도록 오류 수정
-

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?