### PR TITLE
[Feat] 거주지 등록 api 추가 및 반납 예정 알림 Redis 갱신 오류 수정

### DIFF
--- a/src/main/java/samryong/domain/bank/nonghyup/provider/NonghyupTransactionProvider.java
+++ b/src/main/java/samryong/domain/bank/nonghyup/provider/NonghyupTransactionProvider.java
@@ -33,6 +33,8 @@ public class NonghyupTransactionProvider {
 
     private String brdtBrno; // 생년월일/사업자번호
 
+    private final String AlreadyExistAccount = "A0013"; // 이미 등록된 계좌
+
     public NonghyupTransactionProvider(
             @Value("${nonghyup.api.access-token}") String accessToken,
             @Value("${nonghyup.api.iscd}") String iscd,
@@ -70,6 +72,9 @@ public class NonghyupTransactionProvider {
 
         if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
             return responseBody.getRgno();
+        }
+        if (responseBody != null && responseBody.getHeader().getRpcd().equals(AlreadyExistAccount)) {
+            return AlreadyExistAccount;
         } else {
             throw new NonghyupException(
                     HttpStatus.BAD_REQUEST,
@@ -102,6 +107,9 @@ public class NonghyupTransactionProvider {
 
         if (responseBody != null && responseBody.getHeader().getRpcd().equals("00000")) {
             return responseBody.getFinAcno();
+        } else if (responseBody != null
+                && responseBody.getHeader().getRpcd().equals(AlreadyExistAccount)) {
+            return AlreadyExistAccount;
         } else {
             throw new NonghyupException(
                     HttpStatus.BAD_REQUEST,

--- a/src/main/java/samryong/domain/member/controller/MemberController.java
+++ b/src/main/java/samryong/domain/member/controller/MemberController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import samryong.domain.account.dto.NonghyupAccountDTO.NonghyupAccountRequestDTO;
 import samryong.domain.account.dto.NonghyupAccountDTO.NonghyupAccountResponseDTO;
+import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationResponseDTO;
 import samryong.domain.member.dto.MemberDTO.MyInformationResponseDTO;
 import samryong.domain.member.entity.Member;
 import samryong.domain.member.service.MemberService;
@@ -37,5 +39,12 @@ public class MemberController {
     @GetMapping("/myPage")
     public ApiResponse<MyInformationResponseDTO> getMyPage(@AuthMember Member member) {
         return ApiResponse.onSuccess("마이페이지 조회 성공", memberService.getMyPage(member.getId()));
+    }
+
+    @Operation(summary = "사용자 주소 등록", description = "사용자의 주소를 입력받아 등록합니다.")
+    @PostMapping("/register/location")
+    public ApiResponse<LocationResponseDTO> registerLocation(
+            @AuthMember Member member, @Valid @RequestBody LocationRequestDTO requestDTO) {
+        return ApiResponse.onSuccess("주소지 등록 성공", memberService.registerLocation(member, requestDTO));
     }
 }

--- a/src/main/java/samryong/domain/member/entity/Member.java
+++ b/src/main/java/samryong/domain/member/entity/Member.java
@@ -122,4 +122,8 @@ public class Member extends BaseEntity {
         this.mannerRate = mannerRate;
         this.mannerCount = mannerCount;
     }
+
+    public void setLocation(Location location) {
+        this.location = location;
+    }
 }

--- a/src/main/java/samryong/domain/member/service/MemberService.java
+++ b/src/main/java/samryong/domain/member/service/MemberService.java
@@ -2,6 +2,8 @@ package samryong.domain.member.service;
 
 import samryong.domain.account.dto.NonghyupAccountDTO.NonghyupAccountRequestDTO;
 import samryong.domain.account.dto.NonghyupAccountDTO.NonghyupAccountResponseDTO;
+import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationResponseDTO;
 import samryong.domain.member.dto.MemberDTO.MyInformationResponseDTO;
 import samryong.domain.member.entity.Member;
 import samryong.domain.rent.entity.Rent;
@@ -11,6 +13,8 @@ public interface MemberService {
     Member getMember(Long memberId);
 
     NonghyupAccountResponseDTO registerAccount(Member member, NonghyupAccountRequestDTO requestDTO);
+
+    LocationResponseDTO registerLocation(Member member, LocationRequestDTO requestDTO);
 
     MyInformationResponseDTO getMyPage(Long memberId);
 

--- a/src/main/java/samryong/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/samryong/domain/member/service/MemberServiceImpl.java
@@ -9,6 +9,11 @@ import samryong.domain.account.dto.NonghyupAccountDTO.NonghyupAccountResponseDTO
 import samryong.domain.account.entity.Account;
 import samryong.domain.account.repository.AccountRepository;
 import samryong.domain.bank.nonghyup.provider.NonghyupTransactionProvider;
+import samryong.domain.location.converter.LocationConverter;
+import samryong.domain.location.dto.LocationDTO.LocationRequestDTO;
+import samryong.domain.location.dto.LocationDTO.LocationResponseDTO;
+import samryong.domain.location.entity.Location;
+import samryong.domain.location.repository.LocationRepository;
 import samryong.domain.member.converter.MemberConverter;
 import samryong.domain.member.dto.MemberDTO.MyInformationResponseDTO;
 import samryong.domain.member.entity.Member;
@@ -22,8 +27,11 @@ import samryong.global.exception.GlobalException;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final LocationRepository locationRepository;
     private final AccountRepository accountRepository;
     private final NonghyupTransactionProvider nonghyupTransactionProvider;
+
+    private final String AlreadyExistAccount = "A0013";
 
     @Override
     public Member getMember(Long memberId) {
@@ -34,21 +42,53 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public NonghyupAccountResponseDTO registerAccount(
             Member member, NonghyupAccountRequestDTO requestDTO) {
-
         String accountNumber = requestDTO.getAccountNumber();
+
+        // 농협에 계좌 등록 요청 및 처리
         String rgNum = nonghyupTransactionProvider.openFinAccountDirect(accountNumber);
-        String finTechAccountNum = nonghyupTransactionProvider.checkOpenFinAccountDirect(rgNum);
+        String finTechAccountNum = getFinTechAccountNum(accountNumber, rgNum);
 
-        Account account = accountRepository.findByAccountNum(accountNumber).orElse(null);
-        if (account != null) {
-            throw new GlobalException(GlobalErrorCode.ACCOUNT_ALREADY_EXIST);
-        }
+        // 계좌 정보를 조회하거나 새로 생성
+        Account account =
+                accountRepository
+                        .findByAccountNum(accountNumber)
+                        .orElseGet(() -> createNewAccount(member, accountNumber, finTechAccountNum));
 
-        account = AccountConverter.toAccount(accountNumber, finTechAccountNum);
-        member.addAccount(account);
-
-        memberRepository.save(member);
         return AccountConverter.toAccountResponseDTO(account);
+    }
+
+    private String getFinTechAccountNum(String accountNumber, String rgNum) {
+        if (rgNum.equals(AlreadyExistAccount)) {
+            return accountRepository
+                    .findByAccountNum(accountNumber)
+                    .map(Account::getFinTechAccountNum)
+                    .orElseThrow(() -> new GlobalException(GlobalErrorCode.ACCOUNT_NOT_FOUND));
+        }
+        return nonghyupTransactionProvider.checkOpenFinAccountDirect(rgNum);
+    }
+
+    private Account createNewAccount(Member member, String accountNumber, String finTechAccountNum) {
+        Account account = AccountConverter.toAccount(accountNumber, finTechAccountNum);
+        member.addAccount(account);
+        return account;
+    }
+
+    @Override
+    @Transactional
+    public LocationResponseDTO registerLocation(Member member, LocationRequestDTO requestDTO) {
+
+        String City = requestDTO.getCity();
+        String District = requestDTO.getDistrict();
+        String Neighborhood = requestDTO.getNeighborhood();
+
+        Location location =
+                locationRepository
+                        .findByCityAndDistrictAndNeighborhood(City, District, Neighborhood)
+                        .orElseThrow(() -> new GlobalException(GlobalErrorCode.LOCATION_NOT_FOUND));
+
+        member.setLocation(location);
+
+        return LocationConverter.toLocationResponseDTO(location);
     }
 
     @Override

--- a/src/main/java/samryong/domain/notice/service/NoticeServiceImpl.java
+++ b/src/main/java/samryong/domain/notice/service/NoticeServiceImpl.java
@@ -10,6 +10,7 @@ import samryong.domain.chat.repository.ChatRoomRepository;
 import samryong.domain.chat.service.ChatMessageService;
 import samryong.domain.notice.converter.NoticeConverter;
 import samryong.domain.rent.entity.Rent;
+import samryong.domain.rent.entity.Rent.RentStatus;
 import samryong.domain.rent.repository.RentRepository;
 import samryong.global.code.GlobalErrorCode;
 import samryong.global.exception.GlobalException;
@@ -54,7 +55,10 @@ public class NoticeServiceImpl implements NoticeService {
                 chatRoomRepository
                         .findByRenterAndOwnerAndItem(rent.getRenter(), rent.getOwner(), rent.getItem())
                         .orElseThrow(() -> new GlobalException(GlobalErrorCode.CHAT_ROOM_NOT_FOUND));
-        chatMessageService.publishMessage(
-                NoticeConverter.toChatMessageRequestDTO(chatRoom, RENT_REMINDER_MESSAGE));
+
+        if (rent.getStatus() == RentStatus.RENT_PROCESS || rent.getStatus() == RentStatus.OVERDUE) {
+            chatMessageService.publishMessage(
+                    NoticeConverter.toChatMessageRequestDTO(chatRoom, RENT_REMINDER_MESSAGE));
+        }
     }
 }

--- a/src/main/java/samryong/domain/rent/service/RentService.java
+++ b/src/main/java/samryong/domain/rent/service/RentService.java
@@ -26,6 +26,8 @@ public interface RentService {
 
     void saveNoticeKey(Long rentId, Long roomId, LocalDateTime endDate);
 
+    void saveNoticeKey(Long rentId, Long roomId, int duration, TimeUnit timeUnit);
+
     // 대여자인지 확인 후 ChatRoom 반환
     ChatRoom getValidatedChatRoomForRenter(Member renter, Long roomId);
 

--- a/src/main/java/samryong/domain/rent/service/impl/RentExpirationServiceImpl.java
+++ b/src/main/java/samryong/domain/rent/service/impl/RentExpirationServiceImpl.java
@@ -116,6 +116,7 @@ public class RentExpirationServiceImpl implements RentExpirationService {
 
         // 3. Redis에 대여 정보 갱신
         rentService.saveRentKey(rent.getId(), roomId, DEFAULT_OVERDUE_HOURS, TimeUnit.HOURS);
+        rentService.saveNoticeKey(rent.getId(), roomId, DEFAULT_OVERDUE_HOURS + 2, TimeUnit.HOURS);
 
         // 4. 연체료 메시지 전송
         chatMessageService.sendRentCommonMessage(owner, roomId, OVERDUE_MESSAGE, OVERDUE);

--- a/src/main/java/samryong/domain/rent/service/impl/RentExpirationServiceImpl.java
+++ b/src/main/java/samryong/domain/rent/service/impl/RentExpirationServiceImpl.java
@@ -116,7 +116,7 @@ public class RentExpirationServiceImpl implements RentExpirationService {
 
         // 3. Redis에 대여 정보 갱신
         rentService.saveRentKey(rent.getId(), roomId, DEFAULT_OVERDUE_HOURS, TimeUnit.HOURS);
-        rentService.saveNoticeKey(rent.getId(), roomId, DEFAULT_OVERDUE_HOURS + 2, TimeUnit.HOURS);
+        rentService.saveNoticeKey(rent.getId(), roomId, DEFAULT_OVERDUE_HOURS - 2, TimeUnit.HOURS);
 
         // 4. 연체료 메시지 전송
         chatMessageService.sendRentCommonMessage(owner, roomId, OVERDUE_MESSAGE, OVERDUE);

--- a/src/main/java/samryong/domain/rent/service/impl/RentServiceImpl.java
+++ b/src/main/java/samryong/domain/rent/service/impl/RentServiceImpl.java
@@ -102,6 +102,11 @@ public class RentServiceImpl implements RentService {
     }
 
     @Override
+    public void saveNoticeKey(Long rentId, Long roomId, int duration, TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(NOTICE + rentId, roomId, duration, timeUnit);
+    }
+
+    @Override
     public ChatRoom getValidatedChatRoomForRenter(Member renter, Long roomId) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(roomId);
         validateRenter(renter, chatRoom);

--- a/src/main/java/samryong/global/code/GlobalErrorCode.java
+++ b/src/main/java/samryong/global/code/GlobalErrorCode.java
@@ -23,6 +23,7 @@ public enum GlobalErrorCode {
     ACCOUNT_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ACCOUNT400", "이미 등록된 계좌입니다."),
     MANNER_RATE_INVALID(HttpStatus.BAD_REQUEST, "MANNER403", "매너 온도는 0~5 사이의 값이어야 합니다."),
     NO_ACCOUNT_REGISTERED(HttpStatus.NOT_FOUND, "ACCOUNT404", "등록된 계좌가 없습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT404", "해당 계좌를 찾을 수 없습니다."),
 
     // 아이템 관련 에러
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM404", "해당 아이템을 찾을 수 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #42 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 사용자 주소지 갱신 및 등록 api 구현
- 반납된 rentId이더라도 반납 예정 알림을 발송되는 오류 수정, 대여 상태가 진행 중이거나 연체 상태인 경우에만 반납 예정 알림 메시지를 보내도록 오류 수정
- 이전에 등록된 계정일 경우 등록 안되는 오류 수정, A0013의 농협 예외 코드를 처리하여 계정 등록 가능하도록 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?