### PR TITLE
:bug: [Bug] 대여 최신 메시지에 가장 오래된 메시지가 반환되는 오류 수정

### DIFF
--- a/src/main/java/samryong/domain/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/samryong/domain/chat/service/ChatMessageServiceImpl.java
@@ -74,8 +74,8 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             List<ChatMessage> dbMessageList =
                     chatMessageRepository.findTop100ByChatRoomIdOrderByCreatedAtDesc(roomId);
 
-            for (ChatMessage chatMessage : dbMessageList) {
-
+            for (int i = dbMessageList.size() - 1; i >= 0; i--) {
+                ChatMessage chatMessage = dbMessageList.get(i);
                 messageList.add(chatMessage);
                 redisTemplateMessage.opsForList().leftPush(key, chatMessage);
             }

--- a/src/main/java/samryong/domain/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/samryong/domain/chat/service/ChatRoomServiceImpl.java
@@ -172,7 +172,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             redisTemplateMessage.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatMessage.class));
 
             // MongoDB에서 가져온 메시지를 Redis에 저장
-            for (ChatMessage chatMessage : dbMessageList) {
+            for (int i = dbMessageList.size() - 1; i >= 0; i--) {
+                ChatMessage chatMessage = dbMessageList.get(i);
                 redisTemplateMessage.opsForList().leftPush(key, chatMessage);
             }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #69 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 캐시에 없는 채팅 메시지 불러올 때 반복문을 역순으로 순회하여 레디스의 가장 상단에 제일 최신 데이터가 조회될 수 있도록 수정


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?